### PR TITLE
Correct handling of empty args and generalize to procfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ web: lein simpleton 8000
 
 The `Procfile` should live at the root of your project.
 
-Then just run `lein cooper`
-
 ```shell
  $ lein cooper
  ```
@@ -88,8 +86,11 @@ Alternatively, you can define your processes in `project.clj` with `:cooper`.
          "web"  ["lein" "simpleton" "8000"]}
 ```
 
-Then run with `lein cooper cljs web`.
+### Running
 
+To run all processes, use `lein cooper`
+
+To run named processes, use something like `lein cooper cljs web`.
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-cooper "1.1.2"
+(defproject lein-cooper "1.2.1"
   :description "Run and combine multiple processes as single process"
   :url "https://github.com/kouphax/lein-cooper"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/cooper.clj
+++ b/src/leiningen/cooper.clj
@@ -48,17 +48,17 @@
           (assoc proc :padded-name padded-name))))))
 
 (defn- get-procs-from-project
-  [project args]
+  [project]
   (let [cooper (:cooper project)]
     (doall
-     (for [task args]
+     (for [task (keys cooper)]
        (let [command-seq (cooper task)]
          (when (nil? command-seq)
            (println (style (str "Cooper process \"" task "\" does not exist") :red))
            (abort))
          (assoc (apply sh/proc command-seq) :name task))))))
 
-(defn- get-procs []
+(defn- get-procs-from-procfile []
   (with-open [buffer (io/reader "Procfile")]
     (doall
       (for [line (line-seq buffer)]
@@ -139,8 +139,8 @@ Sorry about the inconvenience." :red))
   [project & args]
   (let [src (use-procfile-or-project project args)
         procs (cond
-                (= src :project) (get-procs-from-project project args)
-                (= src :procfile) (get-procs))]
+                (= src :project) (get-procs-from-project project)
+                (= src :procfile) (get-procs-from-procfile))]
     (doto (-> procs calculate-padding)
       (pipe-procs)
       (wait-for-early-exit)


### PR DESCRIPTION
This adds support for specifying proc names on the command lines when using a procfile. It also corrects an error formerly thrown on an empty arg list.