### PR TITLE
bash wrapper

### DIFF
--- a/resources/bash-wrapper.sh
+++ b/resources/bash-wrapper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+# http://stackoverflow.com/a/26966800/84283
+kill_descendant_processes() {
+    local pid="$1"
+    local and_self="${2:-false}"
+    if children="$(pgrep -P "$pid")"; then
+        for child in $children; do
+            kill_descendant_processes "$child" true
+        done
+    fi
+    if [[ "$and_self" == true ]]; then
+        kill -9 "$pid"
+    fi
+}
+
+trap "kill_descendant_processes $$; trap - EXIT; exit 0" EXIT
+
+export COOPER_SPAWN=1
+
+lein "$@"


### PR DESCRIPTION
I started using lein-cooper in [my dirac project](https://github.com/binaryage/dirac) quite heavily (spawning [a lot of tasks](https://github.com/binaryage/dirac/blob/766050868ffb5189bb1d686576df62ae7f56e2bf/project.clj#L325) in via single lein cooper invocation. The problem was occasional need for manual cleanup of background processed when something went wrong. It is not fun to fish for PID of hairy java processes which all look the same.

I'm not much experienced in java stuff. But I came up with this solution. I wrap lein cooper invocation in a bash script which does the cleanup in all cases. Of course this is not a platform independent solution. I will work only on systems with bash.

I'm posting it as a proposal, maybe we can work together on a more robust solution.