### PR TITLE
Ensure all command arguments are strings

### DIFF
--- a/src/leiningen/cooper.clj
+++ b/src/leiningen/cooper.clj
@@ -58,7 +58,8 @@
   (let [cooper (:cooper project)]
     (doall
      (for [proc-name (keys cooper)]
-       (assoc (apply sh/proc (cooper proc-name)) :name proc-name)))))
+       (assoc (apply sh/proc (map str (cooper proc-name)))
+              :name proc-name)))))
 
 (defn- get-procs-from-procfile []
   (with-open [buffer (io/reader "Procfile")]


### PR DESCRIPTION
Prevent conch exception if one of the arguments is not a string
(either because the user passes e.g. a port number as a number or
because she inserts an "invisible" space-like-but-not-space character
that ends up as a Symbol, as happened to me)